### PR TITLE
Allow proper NoneType conversions when handling nested dataclass members and such.

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -14,6 +14,7 @@ import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from functools import lru_cache
+from types import NoneType
 from typing import Dict, List, NamedTuple, Optional, Type, cast
 from dataclasses_json import DataClassJsonMixin, dataclass_json
 from flyteidl.core import literals_pb2
@@ -1161,7 +1162,7 @@ class TypeEngine(typing.Generic[T]):
                 "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
                 "return v.x, instead of v, even if this has a single element"
             )
-        if python_val is None and expected and expected.union_type is None:
+        if python_val is None and python_type != NoneType and expected and expected.union_type is None:
             raise TypeTransformerFailedError(f"Python value cannot be None, expected {python_type}/{expected}")
         transformer = cls.get_transformer(python_type)
         if transformer.type_assertions_enabled:


### PR DESCRIPTION
Before:
```
TypeError: Failed to convert inputs of task 'workflows.subgraphs.geometric_filtering.build_geometric_filtering_outputs':
  Failed argument 'density': Python value cannot be None, expected <class 'NoneType'>/[Flyte Serialized object: Type: 
<LiteralType> Value: <simple: NONE>]
```
This is pretty nonsensical, upset that the value is `None` when `NoneType` is expected.

The fix is pretty simple, and this no longer happens.